### PR TITLE
Add minimumDisplayTime property

### DIFF
--- a/JGProgressHUD/JGProgressHUD/JGProgressHUD.h
+++ b/JGProgressHUD/JGProgressHUD/JGProgressHUD.h
@@ -251,6 +251,13 @@ typedef NS_ENUM(NSUInteger, JGProgressHUDInteractionType) {
 - (void)setProgress:(float)progress animated:(BOOL)animated;
 
 
+/**
+ Specify a minimum time that the HUD will be on-screen. Useful to prevent the HUD from flashing quickly on the screen when network operations complete more quickly than expected.
+ 
+ @b Default: 0.0.
+ */
+@property (nonatomic, assign) NSTimeInterval minimumDisplayTime;
+
 /////////////
 // Showing //
 /////////////

--- a/JGProgressHUD/JGProgressHUD/JGProgressHUD.m
+++ b/JGProgressHUD/JGProgressHUD/JGProgressHUD.m
@@ -42,6 +42,8 @@
     BOOL _dismissAfterTransitionFinished;
     BOOL _dismissAfterTransitionFinishedWithAnimation;
     
+    CFAbsoluteTime _displayTime;
+    
     JGProgressHUDIndicatorView *_indicatorViewAfterTransitioning;
 }
 
@@ -328,6 +330,7 @@ static CGRect keyboardFrame = (CGRect){{0.0f, 0.0f}, {0.0f, 0.0f}};
     self.hidden = NO;
     
     _transitioning = NO;
+    _displayTime = CFAbsoluteTimeGetCurrent();
     
     if (_indicatorViewAfterTransitioning) {
         self.indicatorView = _indicatorViewAfterTransitioning;
@@ -389,6 +392,8 @@ static CGRect keyboardFrame = (CGRect){{0.0f, 0.0f}, {0.0f, 0.0f}};
     
     _transitioning = YES;
     
+    _displayTime = 0;
+    
     if ([self.delegate respondsToSelector:@selector(progressHUD:willPresentInView:)]) {
         [self.delegate progressHUD:self willPresentInView:view];
     }
@@ -433,6 +438,15 @@ static CGRect keyboardFrame = (CGRect){{0.0f, 0.0f}, {0.0f, 0.0f}};
     
     if (self.targetView == nil) {
         return;
+    }
+    
+    if (self.minimumDisplayTime > 0 && _displayTime > 0) {
+        CFAbsoluteTime displayedTime = CFAbsoluteTimeGetCurrent() - _displayTime;
+        if (displayedTime < self.minimumDisplayTime) {
+            NSTimeInterval delay = self.minimumDisplayTime - displayedTime;
+            [self dismissAfterDelay:delay animated:animated];
+            return;
+        }
     }
     
     _transitioning = YES;


### PR DESCRIPTION
Suppose you show a HUD during a network request, but that request completes very quickly. Without this feature, the HUD appears and then quickly disappears, flashing too quickly on the screen. Prevent quick flashes by allowing specification of a “minimumDisplayTime”.