### PR TITLE
Fix iPad rotation not being observed 

### DIFF
--- a/JGProgressHUD/JGProgressHUD/JGProgressHUD.h
+++ b/JGProgressHUD/JGProgressHUD/JGProgressHUD.h
@@ -223,13 +223,13 @@
 
 
 /**
- Shows the HUD animated. You should preferably show the HUD in a UIViewController's view.
+ Shows the HUD animated. You should preferably show the HUD in a UIViewController's view. The HUD will be repositioned in response to rotation and keyboard show/hide notifications.
  @param view The view to show the HUD in. The frame of the @c view will be used to calculate the position of the HUD.
  */
 - (void)showInView:(UIView *)view;
 
 /**
- Shows the HUD. You should preferably show the HUD in a UIViewController's view.
+ Shows the HUD. You should preferably show the HUD in a UIViewController's view.  The HUD will be repositioned in response to rotation and keyboard show/hide notifications.
  @param view The view to show the HUD in. The frame of the @c view will be used to calculate the position of the HUD.
  @param animated If the HUD should show with an animation.
  */

--- a/JGProgressHUD/JGProgressHUD/JGProgressHUD.h
+++ b/JGProgressHUD/JGProgressHUD/JGProgressHUD.h
@@ -109,12 +109,12 @@
 @property (nonatomic, strong, readonly) UIView *contentView;
 
 /**
- The label used to present text on the HUD. set the @c text property of this label to change the displayed text. You may not change the label's @c frame or @c bounds.
+ The label used to present text on the HUD. Set the @c text property of this label to change the displayed text. You may not change the label's @c frame or @c bounds.
  */
 @property (nonatomic, strong, readonly) UILabel *textLabel;
 
 /**
- The label used to present detail text on the HUD. set the @c text property of this label to change the displayed text. You may not change the label's @c frame or @c bounds.
+ The label used to present detail text on the HUD. Set the @c text property of this label to change the displayed text. You may not change the label's @c frame or @c bounds.
  */
 @property (nonatomic, strong, readonly) UILabel *detailTextLabel;
 
@@ -231,7 +231,7 @@
 /**
  Shows the HUD. You should preferably show the HUD in a UIViewController's view.
  @param view The view to show the HUD in. The frame of the @c view will be used to calculate the position of the HUD.
- @param animated If th HUD should show with an animation.
+ @param animated If the HUD should show with an animation.
  */
 - (void)showInView:(UIView *)view animated:(BOOL)animated;
 
@@ -243,10 +243,10 @@
 - (void)showInRect:(CGRect)rect inView:(UIView *)view;
 
 /**
- Shows the HUD animated. You should preferably show the HUD in a UIViewController's view.
+ Shows the HUD. You should preferably show the HUD in a UIViewController's view.
  @param view The view to show the HUD in.
  @param rect The rect allocated in @c view for displaying the HUD.
- @param animated If th HUD should show with an animation.
+ @param animated If the HUD should show with an animation.
  */
 - (void)showInRect:(CGRect)rect inView:(UIView *)view animated:(BOOL)animated;
 

--- a/JGProgressHUD/JGProgressHUD/JGProgressHUD.m
+++ b/JGProgressHUD/JGProgressHUD/JGProgressHUD.m
@@ -372,11 +372,6 @@ static CGRect keyboardFrame = (CGRect){{0.0f, 0.0f}, {0.0f, 0.0f}};
 - (void)showInView:(UIView *)view animated:(BOOL)animated {
     CGRect frame = [self fullFrameInView:view];
     
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(orientationChanged) name:UIDeviceOrientationDidChangeNotification object:nil];
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardFrameChanged:) name:UIKeyboardWillChangeFrameNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardFrameChanged:) name:UIKeyboardDidChangeFrameNotification object:nil];
-    
     [self showInRect:frame inView:view animated:animated];
 }
 
@@ -394,6 +389,11 @@ static CGRect keyboardFrame = (CGRect){{0.0f, 0.0f}, {0.0f, 0.0f}};
 #endif
         return;
     }
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(orientationChanged) name:UIDeviceOrientationDidChangeNotification object:nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardFrameChanged:) name:UIKeyboardWillChangeFrameNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardFrameChanged:) name:UIKeyboardDidChangeFrameNotification object:nil];
     
     _targetView = view;
     

--- a/JGProgressHUD/JGProgressHUD/JGProgressHUD.m
+++ b/JGProgressHUD/JGProgressHUD/JGProgressHUD.m
@@ -372,6 +372,12 @@ static CGRect keyboardFrame = (CGRect){{0.0f, 0.0f}, {0.0f, 0.0f}};
 - (void)showInView:(UIView *)view animated:(BOOL)animated {
     CGRect frame = [self fullFrameInView:view];
     
+    // !!!: Use UIApplicationDidChangeStatusBarFrameNotification since UIDeviceOrientationDidChangeNotification still gives the old bounds in orientationChanged selector for self.targetView on iPad unless it is called after a delay.
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(orientationChanged) name:UIApplicationDidChangeStatusBarFrameNotification object:nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardFrameChanged:) name:UIKeyboardWillChangeFrameNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardFrameChanged:) name:UIKeyboardDidChangeFrameNotification object:nil];
+    
     [self showInRect:frame inView:view animated:animated];
 }
 
@@ -389,12 +395,6 @@ static CGRect keyboardFrame = (CGRect){{0.0f, 0.0f}, {0.0f, 0.0f}};
 #endif
         return;
     }
-    
-    // !!!: Use UIApplicationDidChangeStatusBarFrameNotification since UIDeviceOrientationDidChangeNotification still gives the old bounds in orientationChanged selector for self.targetView on iPad unless it is called after a delay.
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(orientationChanged) name:UIApplicationDidChangeStatusBarFrameNotification object:nil];
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardFrameChanged:) name:UIKeyboardWillChangeFrameNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardFrameChanged:) name:UIKeyboardDidChangeFrameNotification object:nil];
     
     _targetView = view;
     

--- a/JGProgressHUD/JGProgressHUD/JGProgressHUD.m
+++ b/JGProgressHUD/JGProgressHUD/JGProgressHUD.m
@@ -390,7 +390,8 @@ static CGRect keyboardFrame = (CGRect){{0.0f, 0.0f}, {0.0f, 0.0f}};
         return;
     }
     
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(orientationChanged) name:UIDeviceOrientationDidChangeNotification object:nil];
+    // !!!: Use UIApplicationDidChangeStatusBarFrameNotification since UIDeviceOrientationDidChangeNotification still gives the old bounds in orientationChanged selector for self.targetView on iPad unless it is called after a delay.
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(orientationChanged) name:UIApplicationDidChangeStatusBarFrameNotification object:nil];
     
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardFrameChanged:) name:UIKeyboardWillChangeFrameNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardFrameChanged:) name:UIKeyboardDidChangeFrameNotification object:nil];


### PR DESCRIPTION
Observe UIApplicationDidChangeStatusBarFrameNotification instead of UIDeviceOrientationDidChangeNotification for detecting screen rotation since the later notification still gives the old bounds for self.targetVew in our orientationChanged selector on iPad unless it is called after a delay.
