### PR TITLE
Expose voiceOverEnabled flag for greater accessibility control

### DIFF
--- a/JGProgressHUD/JGProgressHUD/JGProgressHUD.h
+++ b/JGProgressHUD/JGProgressHUD/JGProgressHUD.h
@@ -219,7 +219,11 @@
  */
 @property (nonatomic, assign) NSTimeInterval minimumDisplayTime;
 
-
+/**
+ Determines whether voiceover announcements should be made upon displaying the HUD.
+ @b Default: YES
+ */
+@property (nonatomic, assign) BOOL voiceOverEnabled;
 
 
 /**

--- a/JGProgressHUD/JGProgressHUD/JGProgressHUD.m
+++ b/JGProgressHUD/JGProgressHUD/JGProgressHUD.m
@@ -115,6 +115,7 @@ static CGRect keyboardFrame = (CGRect){{0.0f, 0.0f}, {0.0f, 0.0f}};
     
     if (self) {
         _style = style;
+        _voiceOverEnabled = YES;
         
         self.hidden = YES;
         self.backgroundColor = [UIColor clearColor];
@@ -360,7 +361,7 @@ static CGRect keyboardFrame = (CGRect){{0.0f, 0.0f}, {0.0f, 0.0f}};
         _dismissAfterTransitionFinishedWithAnimation = NO;
     }
     
-    if (UIAccessibilityIsVoiceOverRunning()) {
+    if (self.voiceOverEnabled && UIAccessibilityIsVoiceOverRunning()) {
         UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, self);
     }
 }


### PR DESCRIPTION
Announcing and changing the accessibility control during a layout change is not always the desired behavior for some uses of this modal. This PR introduces a flag to disable voice over announcements on demand.