### PR TITLE
Fix codesigning resource error

### DIFF
--- a/JGProgressHUD.xcodeproj/project.pbxproj
+++ b/JGProgressHUD.xcodeproj/project.pbxproj
@@ -515,6 +515,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGNING_REQUIRED = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -536,6 +538,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGNING_REQUIRED = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				INFOPLIST_FILE = "";


### PR DESCRIPTION
Getting the following error when building with simulator, under Xcode 8.1:
`Error: JGProgressHUD Resources.bundle: bundle format unrecognized, invalid, or unsuitable
Command /usr/bin/codesign failed with exit code 1`

Awesome project btw, Jonas!
