### PR TITLE
Specified swift version in podspec

### DIFF
--- a/JGProgressHUD.podspec
+++ b/JGProgressHUD.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
   s.source_files 	= "JGProgressHUD/JGProgressHUD/*.{h,m}"
   s.resource_bundle 	= { "JGProgressHUD" => "JGProgressHUD/Resources/*.png" }
   s.frameworks 	 	= "Foundation", "UIKit", "QuartzCore"
+  s.swift_version = "4.0"
   s.requires_arc 	= true
 
 end


### PR DESCRIPTION
JGProgressHUD will not build for me in Xcode 10.1 unless I manually change the Swift version in the pod settings. This PR fixes it by specifying the swift version in the podspec.