### PR TITLE
Add support for any SwiftPM-based dependency manager 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "JGProgressHUD",
+    products: [
+        .library(name: "JGProgressHUD", targets: ["JGProgressHUD"])
+    ],
+    targets: [
+        .target(
+            name: "JGProgressHUD"
+        )
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,8 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "JGProgressHUD"
+            name: "JGProgressHUD",
+            path: "JGProgressHUD"
         )
     ]
 )


### PR DESCRIPTION
This adds a very basic [SwiftPM](https://github.com/apple/swift-package-manager) manifest file to be compatible with any dependency manager that uses Apples official way of specifying libraries.

Note that I created this PR because I'm currently developing a dependency manager called [Accio](https://github.com/JamitLabs/Accio) which is intended to fix several issues with Carthage and fill the gap between now and the time, when Apple adds official support for SwiftPM into Xcode. Merging this will also prepare for that bright future.

Please note that this project is part of Accio's official [integration tests](https://github.com/JamitLabs/Accio/tree/work/1000-frameworks/Demo/Shared/AppDependencies) within the [Demo project](https://github.com/JamitLabs/Accio/tree/work/1000-frameworks/Demo).