### PR TITLE
use angle brackets for public includes

### DIFF
--- a/JGProgressHUD/JGProgressHUD/JGProgressHUD.h
+++ b/JGProgressHUD/JGProgressHUD/JGProgressHUD.h
@@ -6,17 +6,17 @@
 //  Copyright (c) 2014 Jonas Gessner. All rights reserved.
 //
 
-#import "JGProgressHUD-Defines.h"
-#import "JGProgressHUDShadow.h"
-#import "JGProgressHUDAnimation.h"
-#import "JGProgressHUDFadeAnimation.h"
-#import "JGProgressHUDFadeZoomAnimation.h"
-#import "JGProgressHUDIndicatorView.h"
-#import "JGProgressHUDErrorIndicatorView.h"
-#import "JGProgressHUDSuccessIndicatorView.h"
-#import "JGProgressHUDRingIndicatorView.h"
-#import "JGProgressHUDPieIndicatorView.h"
-#import "JGProgressHUDIndeterminateIndicatorView.h"
+#import <JGProgressHUD/JGProgressHUD-Defines.h>
+#import <JGProgressHUD/JGProgressHUDShadow.h>
+#import <JGProgressHUD/JGProgressHUDAnimation.h>
+#import <JGProgressHUD/JGProgressHUDFadeAnimation.h>
+#import <JGProgressHUD/JGProgressHUDFadeZoomAnimation.h>
+#import <JGProgressHUD/JGProgressHUDIndicatorView.h>
+#import <JGProgressHUD/JGProgressHUDErrorIndicatorView.h>
+#import <JGProgressHUD/JGProgressHUDSuccessIndicatorView.h>
+#import <JGProgressHUD/JGProgressHUDRingIndicatorView.h>
+#import <JGProgressHUD/JGProgressHUDPieIndicatorView.h>
+#import <JGProgressHUD/JGProgressHUDIndeterminateIndicatorView.h>
 
 @protocol JGProgressHUDDelegate;
 

--- a/JGProgressHUD/JGProgressHUD/JGProgressHUDErrorIndicatorView.h
+++ b/JGProgressHUD/JGProgressHUD/JGProgressHUDErrorIndicatorView.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Jonas Gessner. All rights reserved.
 //
 
-#import "JGProgressHUDImageIndicatorView.h"
+#import <JGProgressHUD/JGProgressHUDImageIndicatorView.h>
 
 /**
  An image indicator showing a cross, representing a failed operation.

--- a/JGProgressHUD/JGProgressHUD/JGProgressHUDFadeAnimation.h
+++ b/JGProgressHUD/JGProgressHUD/JGProgressHUDFadeAnimation.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Jonas Gessner. All rights reserved.
 //
 
-#import "JGProgressHUDAnimation.h"
+#import <JGProgressHUD/JGProgressHUDAnimation.h>
 
 /**
  A simple fade animation that fades the HUD from alpha @c 0.0 to alpha @c 1.0.

--- a/JGProgressHUD/JGProgressHUD/JGProgressHUDFadeZoomAnimation.h
+++ b/JGProgressHUD/JGProgressHUD/JGProgressHUDFadeZoomAnimation.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Jonas Gessner. All rights reserved.
 //  
 
-#import "JGProgressHUDAnimation.h"
+#import <JGProgressHUD/JGProgressHUDAnimation.h>
 
 /**
  An animation that fades in the HUD and expands the HUD from scale @c (0, 0) to a customizable scale, and finally to scale @c (1, 1), creating a bouncing effect.

--- a/JGProgressHUD/JGProgressHUD/JGProgressHUDImageIndicatorView.h
+++ b/JGProgressHUD/JGProgressHUD/JGProgressHUDImageIndicatorView.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Jonas Gessner. All rights reserved.
 //
 
-#import "JGProgressHUDIndicatorView.h"
+#import <JGProgressHUD/JGProgressHUDIndicatorView.h>
 
 /**
  An indicator for displaying custom images. Supports animated images.

--- a/JGProgressHUD/JGProgressHUD/JGProgressHUDIndeterminateIndicatorView.h
+++ b/JGProgressHUD/JGProgressHUD/JGProgressHUDIndeterminateIndicatorView.h
@@ -6,8 +6,8 @@
 //  Copyright (c) 2014 Jonas Gessner. All rights reserved.
 //
 
-#import "JGProgressHUD-Defines.h"
-#import "JGProgressHUDIndicatorView.h"
+#import <JGProgressHUD/JGProgressHUD-Defines.h>
+#import <JGProgressHUD/JGProgressHUDIndicatorView.h>
 
 /**
  An indeterminate progress indicator showing a @c UIActivityIndicatorView.

--- a/JGProgressHUD/JGProgressHUD/JGProgressHUDIndicatorView.h
+++ b/JGProgressHUD/JGProgressHUD/JGProgressHUDIndicatorView.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
-#import "JGProgressHUD-Defines.h"
+#import <JGProgressHUD/JGProgressHUD-Defines.h>
 
 /** You may subclass this class to create a custom progress indicator view. */
 @interface JGProgressHUDIndicatorView : UIView

--- a/JGProgressHUD/JGProgressHUD/JGProgressHUDPieIndicatorView.h
+++ b/JGProgressHUD/JGProgressHUD/JGProgressHUDPieIndicatorView.h
@@ -6,8 +6,8 @@
 //  Copyright (c) 2014 Jonas Gessner. All rights reserved.
 //
 
-#import "JGProgressHUD-Defines.h"
-#import "JGProgressHUDIndicatorView.h"
+#import <JGProgressHUD/JGProgressHUD-Defines.h>
+#import <JGProgressHUD/JGProgressHUDIndicatorView.h>
 
 /**
  A pie shaped determinate progress indicator.

--- a/JGProgressHUD/JGProgressHUD/JGProgressHUDRingIndicatorView.h
+++ b/JGProgressHUD/JGProgressHUD/JGProgressHUDRingIndicatorView.h
@@ -6,8 +6,8 @@
 //  Copyright (c) 2014 Jonas Gessner. All rights reserved.
 //
 
-#import "JGProgressHUD-Defines.h"
-#import "JGProgressHUDIndicatorView.h"
+#import <JGProgressHUD/JGProgressHUD-Defines.h>
+#import <JGProgressHUD/JGProgressHUDIndicatorView.h>
 
 /**
  A ring shaped determinate progress indicator.

--- a/JGProgressHUD/JGProgressHUD/JGProgressHUDSuccessIndicatorView.h
+++ b/JGProgressHUD/JGProgressHUD/JGProgressHUDSuccessIndicatorView.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Jonas Gessner. All rights reserved.
 //
 
-#import "JGProgressHUDImageIndicatorView.h"
+#import <JGProgressHUD/JGProgressHUDImageIndicatorView.h>
 
 /**
  An image indicator showing a checkmark, representing a failed operation.


### PR DESCRIPTION
The following newish Xcode warning complains otherwise:
> Warns when a quoted include is used instead of a framework style include in a framework header.

I tested by adding JGProgressHUD as a subproject (via xcodeproj).