### PR TITLE
Fixes #127: Implement dismissal completion block

### DIFF
--- a/JGProgressHUD/JGProgressHUD/JGProgressHUD.m
+++ b/JGProgressHUD/JGProgressHUD/JGProgressHUD.m
@@ -514,6 +514,10 @@ static CGRect keyboardFrame = (CGRect){{0.0, 0.0}, {0.0, 0.0}};
     if ([self.delegate respondsToSelector:@selector(progressHUD:didDismissFromView:)]) {
         [self.delegate progressHUD:self didDismissFromView:targetView];
     }
+
+    if (_dismissCompletionBlock) {
+        self.dismissCompletionBlock(self);
+    }
 }
 
 - (void)dismiss {

--- a/JGProgressHUD/JGProgressHUD/include/JGProgressHUD.h
+++ b/JGProgressHUD/JGProgressHUD/include/JGProgressHUD.h
@@ -202,6 +202,11 @@
 #endif
 
 /**
+ A block to be invoked when the HUD did dismiss.
+ */
+@property (nonatomic, copy, nullable) void (^dismissCompletionBlock)(JGProgressHUD *__nonnull HUD);
+
+/**
  Shows the HUD animated. You should preferably show the HUD in a UIViewController's view. The HUD will be repositioned in response to rotation and keyboard show/hide notifications.
  @param view The view to show the HUD in. The frame of the @c view will be used to calculate the position of the HUD.
  */


### PR DESCRIPTION
Fixes #127.

This adds a basic completion block to be called when dismissal is completed alongside the existing delegates.

Could possibly also add a handler for willDismiss if wanted.