### PR TITLE
add [JGProgressHUD showInView:animated:afterDelay]

### DIFF
--- a/JGProgressHUD/JGProgressHUD/include/JGProgressHUD.h
+++ b/JGProgressHUD/JGProgressHUD/include/JGProgressHUD.h
@@ -226,6 +226,7 @@
 
 /**
  Shows the HUD after a delay. You should preferably show the HUD in a UIViewController's view. The HUD will be repositioned in response to rotation and keyboard show/hide notifications.
+ You may call @c dismiss to stop the HUD from appearing before the delay has passed.
  @param view The view to show the HUD in. The frame of the @c view will be used to calculate the position of the HUD.
  @param animated If the HUD should show with an animation.
  @param afterDelay The delay until the HUD will be shown.

--- a/JGProgressHUD/JGProgressHUD/include/JGProgressHUD.h
+++ b/JGProgressHUD/JGProgressHUD/include/JGProgressHUD.h
@@ -224,6 +224,14 @@
  */
 - (void)showInView:(UIView *__nonnull)view animated:(BOOL)animated;
 
+/**
+ Shows the HUD after a delay. You should preferably show the HUD in a UIViewController's view. The HUD will be repositioned in response to rotation and keyboard show/hide notifications.
+ @param view The view to show the HUD in. The frame of the @c view will be used to calculate the position of the HUD.
+ @param animated If the HUD should show with an animation.
+ @param afterDelay The delay until the HUD will be shown.
+ */
+- (void)showInView:(UIView *__nonnull)view animated:(BOOL)animated afterDelay:(NSTimeInterval)delay;
+
 /** Dismisses the HUD animated. If the HUD is currently not visible this method does nothing. */
 - (void)dismiss;
 


### PR DESCRIPTION
This PR adds ability to show a HUD after given delay, still maintaining consistency so that you can easily

``[hud showInView:view animated:true afterDelay:1]`` when starting the refresh operation in a view controller
``[hud dismiss]`` when leaving the view controller

